### PR TITLE
하브루타 과목 저장 및 페이지 저장

### DIFF
--- a/src/components/Board/Edit/BoardEdit.tsx
+++ b/src/components/Board/Edit/BoardEdit.tsx
@@ -9,6 +9,7 @@ import { QUERY_KEY } from '~/api/queryKey';
 import { useMarkdownEditor } from '../Write/Markdown';
 import { Editor } from '@toast-ui/react-editor';
 import styles from './BoardEdit.module.css';
+import LoadingSpinner from '~/components/Common/LoadingSpinner';
 
 interface BoardEditProps {
   category: number;

--- a/src/components/Havruta/HavrutaBoard/List/HavrutaBoardContainer.tsx
+++ b/src/components/Havruta/HavrutaBoard/List/HavrutaBoardContainer.tsx
@@ -78,8 +78,8 @@ function HavrutaBoardContainer() {
 
   const totalPage =
     selectedHavrutaId === null
-      ? havrutaBoardQuery.data?.totalPages || 1
-      : havrutaBoardByHavrutaIdQuery.data?.totalPages || 1;
+      ? havrutaBoardQuery.data?.totalPages || 0
+      : havrutaBoardByHavrutaIdQuery.data?.totalPages || 0;
 
   return (
     <HavrutaBoardList

--- a/src/components/Havruta/HavrutaBoard/List/HavrutaBoardList.tsx
+++ b/src/components/Havruta/HavrutaBoard/List/HavrutaBoardList.tsx
@@ -28,20 +28,24 @@ export default function HavrutaBoardList({
   onHavrutaChange,
 }: HavrutaBoardListProps) {
   const renderBoardContent = () => {
-    if (havrutaBoardQuery != null) {
-      return havrutaBoardQuery
-        .filter((havrutaBoard) => havrutaBoard.id !== undefined)
-        .map((havrutaBoard, index) => (
-          <div key={`havruta-${havrutaBoard.id}`}>
-            <div className={styles['board-wrapper']}>
-              <HavrutaBoardItem havrutaBoard={havrutaBoard} />
-            </div>
-            {index < havrutaBoardQuery.length - 1 && (
-              <div className={styles.divider}></div>
-            )}
-          </div>
-        ));
+    if (!havrutaBoardQuery || havrutaBoardQuery.length === 0) {
+      return (
+        <div className={styles.container}>게시물이 존재하지 않습니다.</div>
+      );
     }
+
+    return havrutaBoardQuery
+      .filter((havrutaBoard) => havrutaBoard.id !== undefined)
+      .map((havrutaBoard, index) => (
+        <div key={`havruta-${havrutaBoard.id}`}>
+          <div className={styles['board-wrapper']}>
+            <HavrutaBoardItem havrutaBoard={havrutaBoard} />
+          </div>
+          {index < havrutaBoardQuery.length - 1 && (
+            <div className={styles.divider}></div>
+          )}
+        </div>
+      ));
   };
 
   return (

--- a/src/components/Havruta/HavrutaBoard/List/Sidebar/HavrutaSidebar.tsx
+++ b/src/components/Havruta/HavrutaBoard/List/Sidebar/HavrutaSidebar.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useEffect } from 'react';
 import { UseQueryResult } from '@tanstack/react-query';
 import { Havruta } from '~/models/Havruta.ts';
 import SelectedDot from '~/assets/images/Dot/Selected-Dot.png';
@@ -19,16 +18,37 @@ function HavrutaSidebar({
   onHavrutaChange,
   onPageChange,
 }: HavrutaSidebarProps) {
-  const navigate = useNavigate();
+  // 컴포넌트 마운트 시 sessionStorage에서 havruta 값 불러오기
+  useEffect(() => {
+    const savedHavrutaId = sessionStorage.getItem('havruta');
+    if (savedHavrutaId) {
+      const havrutaId = parseInt(savedHavrutaId, 10);
+      const isValidHavruta = havrutaQuery.data?.some(
+        (havruta) => havruta.id === havrutaId,
+      );
+      if (isValidHavruta) {
+        onHavrutaChange(havrutaId);
+      } else {
+        sessionStorage.removeItem('havruta'); // 유효하지 않은 경우 제거
+      }
+    }
+  }, [havrutaQuery.data, onHavrutaChange]);
 
   if (havrutaQuery.isLoading) return <LoadingSpinner />;
   if (havrutaQuery.isError) return <div>ERROR!</div>;
 
   const handleHavrutaChange = (id: number | null, event: React.MouseEvent) => {
-    event.preventDefault(); // 클릭 시 기본 동작 방지 (URL에 # 추가 방지)
+    event.preventDefault(); // 클릭 시 기본 동작 방지
     onHavrutaChange(id);
+
+    if (id === null) {
+      sessionStorage.removeItem('havruta'); // 전체 선택 시 제거
+    } else {
+      sessionStorage.setItem('havruta', String(id));
+    }
+    sessionStorage.setItem('currentPage', '0');
+
     onPageChange(0); // 페이지를 1로 설정 (0 -> 페이지 1)
-    void navigate(`?havrutaId=${id ? id : 'all'}&page=1`); // havrutaID와 page를 쿼리 파라미터로 추가
   };
 
   return (
@@ -39,11 +59,8 @@ function HavrutaSidebar({
           selectedHavrutaId === null ? styles.selected : ''
         }`}
       >
-        <img src={SelectedDot} loading="lazy" />
-        <a
-          href="#"
-          onClick={(event) => handleHavrutaChange(null, event)} // 전체 선택 시
-        >
+        <img src={SelectedDot} loading="lazy" alt="Selected" />
+        <a href="#" onClick={(event) => handleHavrutaChange(null, event)}>
           전체
         </a>
       </li>
@@ -54,10 +71,10 @@ function HavrutaSidebar({
             selectedHavrutaId === havruta.id ? styles.selected : ''
           }`}
         >
-          <img src={SelectedDot} loading="lazy" />
+          <img src={SelectedDot} loading="lazy" alt="Selected" />
           <a
             href="#"
-            onClick={(event) => handleHavrutaChange(havruta.id ?? null, event)} // 개별 과목 선택 시
+            onClick={(event) => handleHavrutaChange(havruta.id ?? null, event)}
           >
             {havruta.className} ({havruta.professor})
           </a>

--- a/src/components/Header/Main-Header/HeaderMain.tsx
+++ b/src/components/Header/Main-Header/HeaderMain.tsx
@@ -39,6 +39,12 @@ export default function HeaderMain() {
     }
   };
 
+  const resetPage = () => {
+    {
+      sessionStorage.setItem('currentPage', '0');
+    }
+  };
+
   // const handleMyInfo = () => {
   //   navigate('/in  fo');
   // };
@@ -81,7 +87,10 @@ export default function HeaderMain() {
                 className={`${styles['link']} ${styles['navbar-link']} ${
                   location.pathname.startsWith(path) ? styles.active : ''
                 }`}
-                onClick={toggleMenu}
+                onClick={() => {
+                  toggleMenu();
+                  resetPage();
+                }}
               >
                 {label}
               </Link>

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,6 +1,7 @@
 import LeftVector from '~/assets/images/Vector/LeftVector.png';
 import RightVector from '~/assets/images/Vector/RightVector.png';
 import styles from './Pagination.module.css';
+import { useEffect } from 'react';
 
 interface PaginationProps {
   totalPages: number;
@@ -13,8 +14,22 @@ function Pagination({
   currentPage,
   onPageChange,
 }: PaginationProps) {
+  // 컴포넌트 마운트 시 sessionStorage에서 페이지 불러오기
+  useEffect(() => {
+    const storedPage = sessionStorage.getItem('currentPage');
+    if (storedPage) {
+      const pageIndex = parseInt(storedPage, 10);
+      if (!isNaN(pageIndex) && pageIndex >= 0 && pageIndex < totalPages) {
+        onPageChange(pageIndex);
+      } else {
+        sessionStorage.removeItem('currentPage');
+      }
+    }
+  }, [onPageChange, totalPages]);
+
   const handlePageChange = (pageIndex: number) => {
     onPageChange(pageIndex);
+    sessionStorage.setItem('currentPage', pageIndex.toString());
   };
 
   if (totalPages === 0) return null;


### PR DESCRIPTION
하브루타 과목 id 및 현재 페이지를 세션에 저장시켜서 게시판 리스트를 다시 불러올 때 항상 1페이지로 가고 항상 전체 과목으로 가던 것을 세션에 저장시켜논 변수를 불러와서 UX를 증가시킴
메인 헤더에서 게시판 이동하면 현재 페이지를 초기화 시켜서 각각 게시판의 페이지들이 서로 침범하지 않게 함