### PR TITLE
[DW]fix(#458): 어드민 라우트 파일 미사용 rootRoute import 제거

### DIFF
--- a/src/routes/adminBookRoutes.ts
+++ b/src/routes/adminBookRoutes.ts
@@ -1,7 +1,6 @@
 import { createRoute } from '@tanstack/react-router';
 import { lazy } from 'react';
 import { adminLayoutRoute } from './adminLayoutRoute';
-import { rootRoute } from './__root';
 
 
 export const adminBookRoute = createRoute({

--- a/src/routes/adminHavrutaRoutes.ts
+++ b/src/routes/adminHavrutaRoutes.ts
@@ -1,7 +1,6 @@
 import { createRoute } from '@tanstack/react-router';
 import { lazy } from 'react';
 import { adminLayoutRoute } from './adminLayoutRoute';
-import { rootRoute } from './__root';
 
 
 export const adminHavrutaRoute = createRoute({

--- a/src/routes/adminItemRoutes.ts
+++ b/src/routes/adminItemRoutes.ts
@@ -1,7 +1,6 @@
 import { createRoute } from '@tanstack/react-router';
 import { lazy } from 'react';
 import { adminLayoutRoute } from './adminLayoutRoute';
-import { rootRoute } from './__root';
 
 
 export const adminItemRoute = createRoute({

--- a/src/routes/adminProjectRoutes.ts
+++ b/src/routes/adminProjectRoutes.ts
@@ -1,7 +1,6 @@
 import { createRoute } from '@tanstack/react-router';
 import { lazy } from 'react';
 import { adminLayoutRoute } from './adminLayoutRoute';
-import { rootRoute } from './__root';
 
 
 export const adminProjectRoute = createRoute({


### PR DESCRIPTION
## Summary
- `adminBookRoutes.ts`, `adminHavrutaRoutes.ts`, `adminItemRoutes.ts`, `adminProjectRoutes.ts` 4개 파일에서 사용하지 않는 `rootRoute` import 제거
- `noUnusedLocals: true` 옵션으로 인해 CI 빌드(`tsc -b`) 시 TS6133 에러 발생하던 문제 수정

## Test plan
- [x] `npx tsc -b` 에러 없이 통과 확인
- [x] 어드민 라우트 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)