### PR TITLE
[DW]fix(#453): 프로젝트 링크 절대경로 보정 및 카드 배지 오버플로우 방지

### DIFF
--- a/src/components/Project/Detail/ProjectAdminDetail.tsx
+++ b/src/components/Project/Detail/ProjectAdminDetail.tsx
@@ -235,6 +235,10 @@ const EmptyValue = styled.span`
   color: #94a3b8;
 `;
 
+function toAbsoluteUrl(url: string) {
+  return /^https?:\/\//i.test(url) ? url : `https://${url}`;
+}
+
 function ProjectAdminDetail() {
   const navigate = useNavigate();
   const currentUrl = window.location.href;
@@ -313,7 +317,7 @@ function ProjectAdminDetail() {
               <FieldLabel>GitHub</FieldLabel>
               {project.gitHubUrl ? (
                 <LinkValue
-                  href={project.gitHubUrl}
+                  href={toAbsoluteUrl(project.gitHubUrl)}
                   target="_blank"
                   rel="noreferrer"
                 >
@@ -327,7 +331,7 @@ function ProjectAdminDetail() {
               <FieldLabel>서비스 URL</FieldLabel>
               {project.serviceUrl ? (
                 <LinkValue
-                  href={project.serviceUrl}
+                  href={toAbsoluteUrl(project.serviceUrl)}
                   target="_blank"
                   rel="noreferrer"
                 >

--- a/src/components/Project/Detail/ProjectDetail.tsx
+++ b/src/components/Project/Detail/ProjectDetail.tsx
@@ -204,6 +204,10 @@ const MemberChip = styled.span`
   color: #334155;
 `;
 
+function toAbsoluteUrl(url: string) {
+  return /^https?:\/\//i.test(url) ? url : `https://${url}`;
+}
+
 function ProjectDetail() {
   const navigate = useNavigate();
   const currentUrl = window.location.href;
@@ -253,7 +257,7 @@ function ProjectDetail() {
               <FieldLabel>GitHub</FieldLabel>
               {project.gitHubUrl ? (
                 <LinkValue
-                  href={project.gitHubUrl}
+                  href={toAbsoluteUrl(project.gitHubUrl)}
                   target="_blank"
                   rel="noreferrer"
                 >
@@ -267,7 +271,7 @@ function ProjectDetail() {
               <FieldLabel>서비스 URL</FieldLabel>
               {project.serviceUrl ? (
                 <LinkValue
-                  href={project.serviceUrl}
+                  href={toAbsoluteUrl(project.serviceUrl)}
                   target="_blank"
                   rel="noreferrer"
                 >

--- a/src/components/Project/Item/ProjectItem.module.css
+++ b/src/components/Project/Item/ProjectItem.module.css
@@ -24,11 +24,7 @@
 
 .accentBar {
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  background: linear-gradient(90deg, #16b8cc, rgba(22, 184, 204, 0.53));
+  background: linear-gradient(#16b8cc);
   border-radius: 4px 4px 0 0;
   opacity: 0;
   transition: opacity 0.2s ease;
@@ -132,4 +128,16 @@
   padding: 3px 10px;
   border-radius: 4px;
   font-family: 'Pretendard Regular';
+}
+
+.moreBadge {
+  font-size: 11px;
+  font-weight: 600;
+  color: #94a3b8;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  padding: 3px 8px;
+  border-radius: 4px;
+  font-family: 'Pretendard SemiBold';
+  flex-shrink: 0;
 }

--- a/src/components/Project/Item/ProjectItem.tsx
+++ b/src/components/Project/Item/ProjectItem.tsx
@@ -2,12 +2,21 @@ import { useNavigate } from 'react-router-dom';
 import { Project } from '~/models/Project.ts';
 import styles from './ProjectItem.module.css';
 
+const MAX_TAGS = 4;
+const MAX_MEMBERS = 4;
+
 export default function ProjectItem({ project }: { project: Project }) {
   const navigate = useNavigate();
 
   const handleClick = () => {
     void navigate(`/project/view/${project.id}`);
   };
+
+  const visibleTags = project.tags?.slice(0, MAX_TAGS) ?? [];
+  const hiddenTagCount = (project.tags?.length ?? 0) - visibleTags.length;
+
+  const visibleMembers = project.members.slice(0, MAX_MEMBERS);
+  const hiddenMemberCount = project.members.length - visibleMembers.length;
 
   return (
     <div className={styles['project-block']} onClick={handleClick}>
@@ -35,14 +44,17 @@ export default function ProjectItem({ project }: { project: Project }) {
       <div className={styles['title']}>{project.serviceName}</div>
 
       <div className={styles['bottomSection']}>
-        {project.tags && project.tags.length > 0 && (
+        {visibleTags.length > 0 && (
           <>
             <div className={styles['tagContainer']}>
-              {project.tags.map((tag) => (
+              {visibleTags.map((tag) => (
                 <span key={tag.id} className={styles['tagPill']}>
                   {tag.name}
                 </span>
               ))}
+              {hiddenTagCount > 0 && (
+                <span className={styles['moreBadge']}>+{hiddenTagCount}</span>
+              )}
             </div>
             <div className={styles['divider']} />
           </>
@@ -64,11 +76,14 @@ export default function ProjectItem({ project }: { project: Project }) {
             <path d="M16 3.13a4 4 0 0 1 0 7.75" />
             <path d="M21 21v-2a4 4 0 0 0-3-3.85" />
           </svg>
-          {project.members.map((member, index) => (
+          {visibleMembers.map((member, index) => (
             <span key={index} className={styles['memberChip']}>
               {member}
             </span>
           ))}
+          {hiddenMemberCount > 0 && (
+            <span className={styles['moreBadge']}>+{hiddenMemberCount}</span>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/Project/List/ProjectList.module.css
+++ b/src/components/Project/List/ProjectList.module.css
@@ -58,11 +58,22 @@
 
 .tagFilterContainer {
   display: flex;
-  flex-wrap: wrap;
+  align-items: center;
   gap: 8px;
   padding-bottom: 24px;
-  max-width: 1200px;
-  margin: 0 auto;
+}
+
+.tagScrollArea {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  flex: 1;
+  min-width: 0;
+}
+
+.tagScrollArea::-webkit-scrollbar {
+  display: none;
 }
 
 .tagFilterButton {
@@ -77,6 +88,7 @@
   font-size: 14px;
   color: #1a202c;
   cursor: pointer;
+  flex-shrink: 0;
   transition:
     background 0.15s,
     color 0.15s;

--- a/src/components/Project/List/ProjectList.tsx
+++ b/src/components/Project/List/ProjectList.tsx
@@ -53,15 +53,17 @@ export default function ProjectList({
           </svg>
           All Projects
         </button>
-        {allTags.map((tag) => (
-          <button
-            key={tag}
-            className={`${styles.tagFilterButton} ${selectedTag === tag ? styles.tagFilterButtonActive : ''}`}
-            onClick={() => setSelectedTag(tag)}
-          >
-            {tag}
-          </button>
-        ))}
+        <div className={styles.tagScrollArea}>
+          {allTags.map((tag) => (
+            <button
+              key={tag}
+              className={`${styles.tagFilterButton} ${selectedTag === tag ? styles.tagFilterButtonActive : ''}`}
+              onClick={() => setSelectedTag(tag)}
+            >
+              {tag}
+            </button>
+          ))}
+        </div>
       </div>
       <div className={styles.boardList}>{renderBoardContent()}</div>
       <div className={styles['board-list-footer']}>

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -17,8 +17,8 @@ export interface Project {
   gitHubUrl: string;
   serviceUrl: string;
   members: string[];
-  tagNames?: string[];   // 전송 시 사용 (프론트 → 백)
-  tags?: ProjectTag[];   // 수신 시 사용 (백 → 프론트)
+  tagNames?: string[]; // 전송 시 사용 (프론트 → 백)
+  tags?: ProjectTag[]; // 수신 시 사용 (백 → 프론트)
   imageUrl?: string;
   deleted?: boolean;
   createdAt?: Date;


### PR DESCRIPTION
## Summary
- `gitHubUrl`, `serviceUrl`에 프로토콜(`http://`, `https://`)이 없는 경우 `https://`를 자동으로 붙여 잘못된 상대경로 이동 버그 수정 (`ProjectDetail`, `ProjectAdminDetail`)
- 프로젝트 카드(`ProjectItem`)에서 태그/팀원이 MAX(4개) 초과 시 나머지를 `+N` 배지로 표시해 카드 레이아웃 변형 방지
- (기타) 프로젝트 아이템 hover 효과 수정
- 프로젝트 페이지 태그 리스트 좌우 스크롤 가능하도록 함

## Test plan
- [x] 프로토콜 없는 URL(예: `github.com/...`) 클릭 시 올바른 외부 링크로 이동하는지 확인
- [x] 태그/팀원이 4개 초과인 프로젝트 카드에서 `+N` 배지가 표시되는지 확인
- [x] 태그/팀원이 4개 이하인 카드는 기존과 동일하게 표시되는지 확인
- [x] 태그 좌우 스크롤 가능한지 확인