### PR TITLE
[DW]feat(#460): 어드민 사이드바 및 홈 빠른 메뉴에서 도서·비품·하브루타 관리 항목 제거

### DIFF
--- a/src/components/Admin/AdminHome.tsx
+++ b/src/components/Admin/AdminHome.tsx
@@ -214,56 +214,6 @@ const IconActivity = () => (
   </svg>
 );
 
-const IconBook = () => (
-  <svg
-    width="17"
-    height="17"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
-    <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
-  </svg>
-);
-
-const IconBox = () => (
-  <svg
-    width="17"
-    height="17"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <rect x="3" y="3" width="7" height="7" />
-    <rect x="14" y="3" width="7" height="7" />
-    <rect x="14" y="14" width="7" height="7" />
-    <rect x="3" y="14" width="7" height="7" />
-  </svg>
-);
-
-const IconOpenBook = () => (
-  <svg
-    width="17"
-    height="17"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
-    <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
-  </svg>
-);
-
 const IconKey = () => (
   <svg
     width="17"
@@ -295,24 +245,6 @@ const quickMenuItems = [
     desc: '회원 목록 및 권한 관리',
     to: '/admin/allusers',
     icon: <IconUsers />,
-  },
-  {
-    label: '도서 관리',
-    desc: '도서 등록 및 대출 현황',
-    to: '/admin/book',
-    icon: <IconBook />,
-  },
-  {
-    label: '비품 관리',
-    desc: '비품 목록 및 대여 관리',
-    to: '/admin/item',
-    icon: <IconBox />,
-  },
-  {
-    label: '하브루타 과목 관리',
-    desc: '스터디 과목 등록 및 수정',
-    to: '/admin/havruta',
-    icon: <IconOpenBook />,
   },
   {
     label: '프로젝트 관리',

--- a/src/components/Admin/AdminSideBar.tsx
+++ b/src/components/Admin/AdminSideBar.tsx
@@ -153,56 +153,6 @@ const IconBell = () => (
   </svg>
 );
 
-const IconBook = () => (
-  <svg
-    width="18"
-    height="18"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
-    <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
-  </svg>
-);
-
-const IconBox = () => (
-  <svg
-    width="18"
-    height="18"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <rect x="3" y="3" width="7" height="7" />
-    <rect x="14" y="3" width="7" height="7" />
-    <rect x="14" y="14" width="7" height="7" />
-    <rect x="3" y="14" width="7" height="7" />
-  </svg>
-);
-
-const IconOpenBook = () => (
-  <svg
-    width="18"
-    height="18"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
-    <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
-  </svg>
-);
-
 const IconActivity = () => (
   <svg
     width="18"
@@ -260,25 +210,6 @@ export default function AdminSideBar() {
           <NavLink to="/admin/notice/write">
             <IconBell />
             공지글 쓰기
-          </NavLink>
-        </MenuItem>
-        <Divider />
-        <MenuItem>
-          <NavLink to="/admin/book">
-            <IconBook />
-            도서 관리
-          </NavLink>
-        </MenuItem>
-        <MenuItem>
-          <NavLink to="/admin/item">
-            <IconBox />
-            비품 관리
-          </NavLink>
-        </MenuItem>
-        <MenuItem>
-          <NavLink to="/admin/havruta">
-            <IconOpenBook />
-            하브루타 과목 관리
           </NavLink>
         </MenuItem>
         <MenuItem>


### PR DESCRIPTION
## Summary

- 어드민 사이드바(`AdminSideBar.tsx`)에서 도서 관리, 비품 관리, 하브루타 과목 관리 메뉴 항목 제거
- 어드민 홈(`AdminHome.tsx`) 빠른 메뉴에서 동일 항목 제거
- 페이지 라우트는 유지, UI 노출만 제거

## Test plan

- [ ] 어드민 사이드바에 도서·비품·하브루타 메뉴가 보이지 않는지 확인
- [ ] 어드민 홈 빠른 메뉴에 해당 항목이 없는지 확인
- [ ] 나머지 사이드바 메뉴(유저 정보, 공지글, 프로젝트, 가입코드)가 정상 동작하는지 확인