### PR TITLE
[DW] feat(#464): 아카데믹 게시글·프로젝트 태그 기능 구현

### DIFF
--- a/src/api/board.ts
+++ b/src/api/board.ts
@@ -1,9 +1,8 @@
 /* eslint-disable */
 // @ts-nocheck
-import { Board, BoardPageList } from '~/models/Board.ts';
+import { Board, BoardPageList, UpdateBoard } from '~/models/Board.ts';
 // import { client } from './client.ts';
 import { authClient } from './auth/authClient.ts';
-import { UpdateBoard } from '~/models/Board.ts';
 import { reissueToken } from './auth/authApi.ts';
 import { useAuthStore } from '~/store/authStore.ts';
 
@@ -129,6 +128,7 @@ export const updateBoards = async (board: UpdateBoard, file: File | null) => {
       imageUrls: board.imageUrls,
       isChangedFile: !!file,
       deleted: false,
+      tags: board.tags,
     };
 
     formData.append(
@@ -167,6 +167,25 @@ export const deleteBoards = async (id: number): Promise<Board> => {
     // 권한이 필요한 작업에 authClient 사용
     const response = await authClient.delete<Board>(`/board/${id}`);
     return response.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export const getAllTags = async (): Promise<{ id: number; name: string }[]> => {
+  try {
+    const response = await authClient.get<{ id: number; name: string }[]>('/tags');
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export const deleteTag = async (tagId: number): Promise<void> => {
+  try {
+    await authClient.delete(`/tags/${tagId}`);
   } catch (error) {
     console.error(error);
     throw error;

--- a/src/components/Board/Delete/BoardDelete.tsx
+++ b/src/components/Board/Delete/BoardDelete.tsx
@@ -3,23 +3,62 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
-import { deleteBoards } from '~/api/board.ts';
+import { deleteBoards, deleteTag } from '~/api/board.ts';
+import { getProjects } from '~/api/project.ts';
 import { QUERY_KEY } from '~/api/queryKey.ts';
+import { BoardTag } from '~/models/Board.ts';
 import { MdDeleteOutline } from 'react-icons/md';
 import styles from './BoardDelete.module.css';
 
 export default function BoardDelete({
   id,
   category,
+  tags,
 }: {
   id: number;
   category: number;
+  tags?: BoardTag[];
 }) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
   const deleteMutation = useMutation({
-    mutationFn: (id: number) => deleteBoards(id),
+    mutationFn: async (id: number) => {
+      if (tags && tags.length > 0) {
+        // 프로젝트 전체를 API로 직접 조회해 사용 중인 태그 이름 수집
+        const firstPage = await getProjects(1, 1000);
+        const totalPages = firstPage.totalPages ?? 1;
+
+        const allProjects = Array.isArray(firstPage.resListProjectDtos)
+          ? (firstPage.resListProjectDtos as any[])
+          : [];
+
+        if (totalPages > 1) {
+          const remainingPages = await Promise.all(
+            Array.from({ length: totalPages - 1 }, (_, i) =>
+              getProjects(i + 2, 1000),
+            ),
+          );
+          remainingPages.forEach((page) => {
+            if (Array.isArray(page.resListProjectDtos)) {
+              allProjects.push(...(page.resListProjectDtos as any[]));
+            }
+          });
+        }
+
+        const projectTagIds = new Set<number>();
+        allProjects.forEach((project) => {
+          project.tags?.forEach((tag: { id: number }) =>
+            projectTagIds.add(tag.id),
+          );
+        });
+
+        // 프로젝트에서 사용 중이지 않은 태그만 삭제
+        const tagsToDelete = tags.filter((tag) => !projectTagIds.has(tag.id));
+        await Promise.all(tagsToDelete.map((tag) => deleteTag(tag.id)));
+      }
+      return deleteBoards(id);
+    },
     onSuccess: async () => {
       await navigate(-1);
       // 게시글 목록 캐시 무효화

--- a/src/components/Board/Delete/BoardDelete.tsx
+++ b/src/components/Board/Delete/BoardDelete.tsx
@@ -3,8 +3,9 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
-import { deleteBoards, deleteTag } from '~/api/board.ts';
+import { deleteBoards, deleteTag, getBoardsByCategory } from '~/api/board.ts';
 import { getProjects } from '~/api/project.ts';
+import { CATEGORY } from '~/constants/category.ts';
 import { QUERY_KEY } from '~/api/queryKey.ts';
 import { BoardTag } from '~/models/Board.ts';
 import { MdDeleteOutline } from 'react-icons/md';
@@ -53,8 +54,29 @@ export default function BoardDelete({
           );
         });
 
-        // 프로젝트에서 사용 중이지 않은 태그만 삭제
-        const tagsToDelete = tags.filter((tag) => !projectTagIds.has(tag.id));
+        // 다른 게시글에서 사용 중인 태그 ID 수집 (현재 삭제할 게시글 제외)
+        const firstBoardPage = await getBoardsByCategory(CATEGORY.ACADEMIC, 1, 1000);
+        const totalBoardPages = firstBoardPage.totalPages ?? 1;
+        const allBoards = [...(firstBoardPage.resListBoardDtos ?? [])];
+        if (totalBoardPages > 1) {
+          const remainingBoardPages = await Promise.all(
+            Array.from({ length: totalBoardPages - 1 }, (_, i) =>
+              getBoardsByCategory(CATEGORY.ACADEMIC, i + 2, 1000),
+            ),
+          );
+          remainingBoardPages.forEach((page) => {
+            allBoards.push(...(page.resListBoardDtos ?? []));
+          });
+        }
+        const otherBoardTagIds = new Set<number>();
+        allBoards
+          .filter((board) => board.id !== id)
+          .forEach((board) => board.tags?.forEach((tag) => otherBoardTagIds.add(tag.id)));
+
+        // 프로젝트와 다른 게시글 어디서도 사용 중이지 않은 태그만 삭제
+        const tagsToDelete = tags.filter(
+          (tag) => !projectTagIds.has(tag.id) && !otherBoardTagIds.has(tag.id),
+        );
         await Promise.all(tagsToDelete.map((tag) => deleteTag(tag.id)));
       }
       return deleteBoards(id);

--- a/src/components/Board/Detail/BoardDetailItem.module.css
+++ b/src/components/Board/Detail/BoardDetailItem.module.css
@@ -91,11 +91,34 @@
   min-height: 200px;
 }
 
+.tag-section {
+  margin-top: 24px;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  background: rgba(44, 180, 219, 0.1);
+  border: 1px solid #c9eef8;
+  color: #1a8fa8;
+  font-size: 13px;
+  font-family: 'Pretendard Regular';
+  padding: 5px 14px;
+  border-radius: 4px;
+}
+
 .comment-count {
   display: flex;
-  justify-content: space-between; /* 양끝 정렬로 변경 */
-  align-items: center; /* 세로 중앙 정렬 추가 */
-  margin: 138px 10px 14px 10px;
+  justify-content: space-between;
+  align-items: center;
+  margin: 40px 10px 14px 10px;
   font-size: 20px;
   color: var(--color-brighter-text);
 }
@@ -109,7 +132,7 @@
 .viewContainer {
   display: flex;
   align-items: center;
-  gap: 10px; /* 원하는 간격(px 단위) */
+  gap: 10px;
   width: 4ch;
 }
 

--- a/src/components/Board/Detail/BoardDetailItem.tsx
+++ b/src/components/Board/Detail/BoardDetailItem.tsx
@@ -100,19 +100,16 @@ export default function BoardDetailItem({
 
   const handleDownload = async () => {
     if (!board.fileUrl) {
-      // alert('다운로드할 파일이 존재하지 않습니다.');
       return;
     }
 
     try {
-      // ResponseType 설정을 통해 바이너리 데이터 처리
       const response = await fetch(board.fileUrl);
       if (!response.ok) throw new Error('다운로드 실패');
 
       const contentType = response.headers.get('content-type');
       const blob = await response.blob();
 
-      // Blob 객체 생성 시 명시적으로 type 지정
       const file = new Blob([blob], {
         type: contentType || 'application/octet-stream',
       });
@@ -123,11 +120,9 @@ export default function BoardDetailItem({
       link.download = extractFileName(board.fileUrl);
       link.click();
 
-      // 메모리 해제
       window.URL.revokeObjectURL(url);
     } catch (error) {
       console.error('파일 다운로드 실패:', error);
-      // alert('파일 다운로드에 실패했습니다. 다시 시도해 주세요.');
     }
   };
 
@@ -212,7 +207,7 @@ export default function BoardDetailItem({
                   >
                     <FaRegEdit size={22} />
                   </Link>
-                  <BoardDelete id={board.id!} category={category} />
+                  <BoardDelete id={board.id!} category={category} tags={board.tags} />
                 </>
               )}
             </div>
@@ -229,6 +224,18 @@ export default function BoardDetailItem({
           <div className={styles['board-content']}>
             <Viewer initialValue={board.content} />
           </div>
+          {board.tags && board.tags.length > 0 && (
+            <div className={styles['tag-section']}>
+              <Divider />
+              <div className={styles['tag-list']}>
+                {board.tags.map((tag) => (
+                  <span key={tag.id} className={styles['tag-chip']}>
+                    {tag.name}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
 
           <div className={styles['comment-count']}>
             <div className={styles['file-section']}>

--- a/src/components/Board/Edit/BoardEdit.module.css
+++ b/src/components/Board/Edit/BoardEdit.module.css
@@ -161,6 +161,39 @@
   cursor: pointer;
 }
 
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.tag-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 20px;
+  background: rgba(44, 180, 219, 0.1);
+  color: #1a8fa8;
+  font-family: 'Pretendard Regular';
+  font-size: 14px;
+}
+
+.tag-remove {
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 11px;
+  padding: 0;
+  line-height: 1;
+  color: #2cb4db;
+}
+
+.tag-remove:hover {
+  color: #1a8fa8;
+}
+
 @media (max-width: 1200px) {
   .edit-container {
     max-width: 886px;

--- a/src/components/Board/Edit/BoardEdit.tsx
+++ b/src/components/Board/Edit/BoardEdit.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 // @ts-nocheck
 import React, { useEffect, useState } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { CATEGORY_STRINGS } from '~/constants/category_strings';
 import { getBoardById, updateBoards } from '~/api/board';
@@ -21,6 +21,8 @@ export default function BoardEdit({ category }: BoardEditProps) {
   const [errors, setErrors] = useState<{ title?: string; content?: string }>(
     {},
   );
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState('');
   const [formData, setFormData] = useState<{
     title: string;
     content: string;
@@ -38,6 +40,8 @@ export default function BoardEdit({ category }: BoardEditProps) {
   const currentUrl = window.location.href;
   const id = currentUrl.substring(currentUrl.lastIndexOf('/') + 1);
   const boardId = Number(id);
+
+  const queryClient = useQueryClient();
 
   const { editorRef, editorConfig } = useMarkdownEditor({
     onContentChange: (content) => {
@@ -64,7 +68,7 @@ export default function BoardEdit({ category }: BoardEditProps) {
         imageUrls: board.imageUrls || [],
         fileUrl: board.fileUrl || '',
       });
-
+      setTags(board.tags?.map((t) => t.name) ?? []);
       editorRef.current.getInstance().setMarkdown(board.content || '');
     }
   }, [boardQuery.data, editorRef.current]);
@@ -85,9 +89,12 @@ export default function BoardEdit({ category }: BoardEditProps) {
         file: fileToUpload ? fileToUpload.name : null,
       };
 
-      return await updateBoards(payload.board, fileToUpload);
+      return await updateBoards({ ...payload.board, tags }, fileToUpload);
     },
     onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEY.board.boardById(boardId),
+      });
       await navigate(-1);
       setTimeout(() => {
         window.scrollTo(0, 0);
@@ -136,6 +143,21 @@ export default function BoardEdit({ category }: BoardEditProps) {
     }
   };
 
+  const handleTagKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      const trimmed = tagInput.trim();
+      if (trimmed && !tags.includes(trimmed)) {
+        setTags((prev) => [...prev, trimmed]);
+      }
+      setTagInput('');
+    }
+  };
+
+  const handleRemoveTag = (tag: string) => {
+    setTags((prev) => prev.filter((t) => t !== tag));
+  };
+
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files.length > 0) {
       setFile(e.target.files[0]);
@@ -155,11 +177,11 @@ export default function BoardEdit({ category }: BoardEditProps) {
   };
 
   // 로딩 상태 처리
-  if (boardQuery.isLoading || boardQuery.isLoading) {
+  if (boardQuery.isLoading) {
     return <LoadingSpinner />;
   }
 
-  if (boardQuery.isError || boardQuery.isError) {
+  if (boardQuery.isError) {
     return <div>에러가 발생했습니다!!</div>;
   }
 
@@ -192,6 +214,33 @@ export default function BoardEdit({ category }: BoardEditProps) {
         </div>
         {errors.content && (
           <p className={styles['error-message']}>{errors.content}</p>
+        )}
+
+        <label htmlFor="tag">태그</label>
+        <input
+          className={styles['input-title']}
+          type="text"
+          id="tag"
+          placeholder="태그를 입력하고 Enter를 누르세요."
+          value={tagInput}
+          onChange={(e) => setTagInput(e.target.value)}
+          onKeyDown={handleTagKeyDown}
+        />
+        {tags.length > 0 && (
+          <div className={styles['tag-list']}>
+            {tags.map((tag) => (
+              <span key={tag} className={styles['tag-chip']}>
+                {tag}
+                <button
+                  type="button"
+                  className={styles['tag-remove']}
+                  onClick={() => handleRemoveTag(tag)}
+                >
+                  ✕
+                </button>
+              </span>
+            ))}
+          </div>
         )}
 
         <label className={styles['file-button']} htmlFor="fileUpload">

--- a/src/components/Board/List/BoardList.module.css
+++ b/src/components/Board/List/BoardList.module.css
@@ -142,6 +142,60 @@
   border: 1px solid var(--color-dark-stroke);
 }
 
+.tagFilterContainer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 24px;
+  padding-left: 17px;
+  padding-right: 17px;
+}
+
+.tagScrollArea {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  flex: 1;
+  min-width: 0;
+}
+
+.tagScrollArea::-webkit-scrollbar {
+  display: none;
+}
+
+.tagFilterButton {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 18px;
+  border-radius: 4px;
+  border: 1px solid #e4e9ef;
+  background: white;
+  font-family: 'Pretendard Regular';
+  font-size: 14px;
+  color: #1a202c;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.tagFilterButton:hover {
+  background: #f1f5f9;
+}
+
+.tagFilterButtonActive {
+  background: #2cb4db;
+  color: white;
+  border-color: #2cb4db;
+}
+
+.tagFilterButtonActive:hover {
+  background: #27a1c3;
+}
+
 .no-result {
   text-align: center;
   font-size: 20px;

--- a/src/components/Board/List/BoardList.tsx
+++ b/src/components/Board/List/BoardList.tsx
@@ -1,15 +1,14 @@
 // import { UseQueryResult } from '@tanstack/react-query';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Board } from '~/models/Board.ts';
 import { CATEGORY_STRINGS } from '~/constants/category_strings.ts';
 import { CATEGORY_STRINGS_EN } from '~/constants/category_strings_en.ts';
+import { CATEGORY } from '~/constants/category.ts';
+import { useAllTags } from '~/hooks/useAllTags.ts';
 import BoardItem from '~/components/Board/Item/BoardItem.tsx';
 import Pagination from '~/components/Pagination/Pagination.tsx';
 import styles from './BoardList.module.css';
-// import { useQuery } from '@tanstack/react-query';
-// import { getPinBoard } from '~/api/pin';
-
-// import LoadingSpinner from '~/components/Common/LoadingSpinner';
 
 interface BoardListProps {
   category: number;
@@ -28,23 +27,23 @@ export default function BoardList({
   currentPage,
   onPageChange,
 }: BoardListProps) {
-  // const { data: pinBoards } = useQuery<Board[]>({
-  //   queryKey: ['pinBoards'],
-  //   queryFn: getPinBoard,
-  // });
+  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+
+  const allTags = useAllTags(category === CATEGORY.ACADEMIC);
+
+  const filteredBoards =
+    category === CATEGORY.ACADEMIC && selectedTag
+      ? boardsQuery.filter((b) => b.tags?.some((t) => t.name === selectedTag))
+      : boardsQuery;
 
   const renderBoardContent = () => {
-    if (boardsQuery.length > 0) {
-      const pinnedBoardIds = pinned ? pinned.map((board) => board.boardId) : [];
-      // 필터링된 게시물에서 핀된 게시물과 일반 게시물 분리
-      const pinnedBoards = boardsQuery.filter((board) =>
-        pinnedBoardIds.includes(board.id),
-      );
-
-      const normalBoards = boardsQuery.filter(
-        (board) => !pinnedBoardIds.includes(board.id),
-      );
-
+    if (filteredBoards.length > 0) {
+      const pinnedBoardIdSet = new Set(pinned?.map((board) => board.boardId));
+      const pinnedBoards: Board[] = [];
+      const normalBoards: Board[] = [];
+      for (const board of filteredBoards) {
+        (pinnedBoardIdSet.has(board.id) ? pinnedBoards : normalBoards).push(board);
+      }
       const combinedBoards = [...pinnedBoards, ...normalBoards];
 
       return combinedBoards.map((board, index) => (
@@ -69,6 +68,33 @@ export default function BoardList({
   return (
     <div className={styles.container}>
       <h2 className={styles.title}>{CATEGORY_STRINGS[category]} 게시판</h2>
+      {category === CATEGORY.ACADEMIC && (
+        <div className={styles.tagFilterContainer}>
+          <button
+            className={`${styles.tagFilterButton} ${selectedTag === null ? styles.tagFilterButtonActive : ''}`}
+            onClick={() => setSelectedTag(null)}
+          >
+            <svg width="13" height="13" viewBox="0 0 13 13" fill="currentColor">
+              <rect x="0" y="0" width="5.5" height="5.5" rx="1" />
+              <rect x="7.5" y="0" width="5.5" height="5.5" rx="1" />
+              <rect x="0" y="7.5" width="5.5" height="5.5" rx="1" />
+              <rect x="7.5" y="7.5" width="5.5" height="5.5" rx="1" />
+            </svg>
+            All
+          </button>
+          <div className={styles.tagScrollArea}>
+            {allTags.map((tag) => (
+              <button
+                key={tag.id}
+                className={`${styles.tagFilterButton} ${selectedTag === tag.name ? styles.tagFilterButtonActive : ''}`}
+                onClick={() => setSelectedTag(tag.name)}
+              >
+                {tag.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
       <div className={styles.boardList}>{renderBoardContent()}</div>
       <div className={styles['board-list-footer']}>
         <div className={styles['spacer']} />
@@ -77,7 +103,7 @@ export default function BoardList({
           currentPage={currentPage}
           onPageChange={onPageChange}
         />
-        {CATEGORY_STRINGS[category] === '학술' ? (
+        {category === CATEGORY.ACADEMIC ? (
           <Link
             className={styles.WriteLink}
             to={`/${CATEGORY_STRINGS_EN[category]}/write`}

--- a/src/components/Board/Write/BoardWrite.module.css
+++ b/src/components/Board/Write/BoardWrite.module.css
@@ -166,6 +166,39 @@
   font-size: 12px;
 }
 
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.tag-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 20px;
+  background: rgba(44, 180, 219, 0.1);
+  color: #1a8fa8;
+  font-family: 'Pretendard Regular';
+  font-size: 14px;
+}
+
+.tag-remove {
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 11px;
+  padding: 0;
+  line-height: 1;
+  color: #2cb4db;
+}
+
+.tag-remove:hover {
+  color: #1a8fa8;
+}
+
 @media (max-width: 1200px) {
   .write-container {
     max-width: 886px;

--- a/src/components/Board/Write/BoardWrite.tsx
+++ b/src/components/Board/Write/BoardWrite.tsx
@@ -10,7 +10,6 @@ import styles from './BoardWrite.module.css';
 import BoardUploadSpinner from '~/components/Common/BoardUploadSpinner.tsx';
 import AlertModal from '~/components/Modal/Alert/AlertModal.tsx';
 import { useModalStore } from '~/store/modalStore.ts';
-import { BiCheckbox, BiPin } from 'react-icons/bi';
 
 interface BoardWriteProps {
   category: number;
@@ -23,6 +22,8 @@ export default function BoardWrite({ category }: BoardWriteProps) {
   );
   const { isOpen: modalIsOpen, openModal, closeModal } = useModalStore();
   const [modalMessage, setModalMessage] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState('');
   const [formData, setFormData] = useState<{
     title: string;
     content: string;
@@ -74,7 +75,7 @@ export default function BoardWrite({ category }: BoardWriteProps) {
       };
 
       return await createBoards(
-        { ...payload.board, likes: 0, liked: false },
+        { ...payload.board, likes: 0, liked: false, tags },
         fileToUpload,
       );
     },
@@ -94,6 +95,8 @@ export default function BoardWrite({ category }: BoardWriteProps) {
         imageUrls: [],
       });
       setFile(null);
+      setTags([]);
+      setTagInput('');
     },
 
     onError: (error) => {
@@ -152,6 +155,21 @@ export default function BoardWrite({ category }: BoardWriteProps) {
     setFile(null);
   };
 
+  const handleTagKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      const trimmed = tagInput.trim();
+      if (trimmed && !tags.includes(trimmed)) {
+        setTags((prev) => [...prev, trimmed]);
+      }
+      setTagInput('');
+    }
+  };
+
+  const handleRemoveTag = (tag: string) => {
+    setTags((prev) => prev.filter((t) => t !== tag));
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!validateForm()) {
@@ -188,6 +206,33 @@ export default function BoardWrite({ category }: BoardWriteProps) {
         </div>
         {errors.content && (
           <p className={styles['error-message']}>{errors.content}</p>
+        )}
+
+        <label htmlFor="tag">태그</label>
+        <input
+          className={styles['input-title']}
+          type="text"
+          id="tag"
+          placeholder="태그를 입력하고 Enter를 누르세요."
+          value={tagInput}
+          onChange={(e) => setTagInput(e.target.value)}
+          onKeyDown={handleTagKeyDown}
+        />
+        {tags.length > 0 && (
+          <div className={styles['tag-list']}>
+            {tags.map((tag) => (
+              <span key={tag} className={styles['tag-chip']}>
+                {tag}
+                <button
+                  type="button"
+                  className={styles['tag-remove']}
+                  onClick={() => handleRemoveTag(tag)}
+                >
+                  ✕
+                </button>
+              </span>
+            ))}
+          </div>
         )}
 
         <label className={styles['file-button']} htmlFor="fileUpload">

--- a/src/components/Comment/List/CommetList.tsx
+++ b/src/components/Comment/List/CommetList.tsx
@@ -1,35 +1,21 @@
 import CommentItem from '~/components/Comment/Item/CommentItem.tsx';
-// import LoadingSpinner from '~/components/Common/LoadingSpinner';
 import { Board } from '~/models/Board';
 
 export default function CommentList({ board }: { board: Board }) {
-  // const commentsQuery = useQuery<Comment[]>({
-  //   queryKey: QUERY_KEY.comment.commentsById(id),
-  //   queryFn: async () => getCommentsByBoardId(id),
-  // });
-  const commentsQuery = board.resListCommentDtos;
-  let content;
+  const commentsQuery = board.resListCommentDtos ?? [];
 
-  // if (commentsQuery.isLoading) {
-  //   content = <LoadingSpinner />;
-  if (!commentsQuery) {
-    content = <div className="error">에러가 발생했습니다!</div>;
-  } else {
-    content = commentsQuery.map((comment) => (
-      <div key={comment.id}>
-        <CommentItem key={comment.id} comment={comment} isRoot={true} />
-        {comment.commentList.map((childComment) => {
-          return (
-            <CommentItem
-              key={childComment.id}
-              comment={childComment}
-              isRoot={false}
-            />
-          );
-        })}
-      </div>
-    ));
-  }
+  const content = commentsQuery.map((comment) => (
+    <div key={comment.id}>
+      <CommentItem comment={comment} isRoot={true} />
+      {comment.commentList.map((childComment) => (
+        <CommentItem
+          key={childComment.id}
+          comment={childComment}
+          isRoot={false}
+        />
+      ))}
+    </div>
+  ));
 
   return <div>{content}</div>;
 }

--- a/src/components/Project/Delete/ProjectAdminDelete.tsx
+++ b/src/components/Project/Delete/ProjectAdminDelete.tsx
@@ -1,5 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteProject } from '~/api/project.ts';
+import { deleteTag, getBoardsByCategory } from '~/api/board.ts';
+import { ProjectTag } from '~/models/Project.ts';
+import { CATEGORY } from '~/constants/category.ts';
 import styled from 'styled-components';
 
 const DeleteButton = styled.button`
@@ -13,11 +16,40 @@ const DeleteButton = styled.button`
   }
 `;
 
-function ProjectAdminDelete({ id }: { id: number }) {
+function ProjectAdminDelete({ id, tags }: { id: number; tags?: ProjectTag[] }) {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: (id: number) => deleteProject(id),
+    mutationFn: async (id: number) => {
+      if (tags && tags.length > 0) {
+        // 아카데믹 게시글 전체를 API로 직접 조회해 사용 중인 태그 ID 수집
+        const firstPage = await getBoardsByCategory(CATEGORY.ACADEMIC, 1, 1000);
+        const totalPages = firstPage.totalPages ?? 1;
+
+        const allBoards = [...(firstPage.resListBoardDtos ?? [])];
+
+        if (totalPages > 1) {
+          const remainingPages = await Promise.all(
+            Array.from({ length: totalPages - 1 }, (_, i) =>
+              getBoardsByCategory(CATEGORY.ACADEMIC, i + 2, 1000),
+            ),
+          );
+          remainingPages.forEach((page) => {
+            allBoards.push(...(page.resListBoardDtos ?? []));
+          });
+        }
+
+        const academicTagIds = new Set<number>();
+        allBoards.forEach((board) => {
+          board.tags?.forEach((tag) => academicTagIds.add(tag.id));
+        });
+
+        // 아카데믹 게시글에서 사용 중이지 않은 태그만 삭제
+        const tagsToDelete = tags.filter((tag) => !academicTagIds.has(tag.id));
+        await Promise.all(tagsToDelete.map((tag) => deleteTag(tag.id)));
+      }
+      return deleteProject(id);
+    },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ['project.projects'] });
       alert('프로젝트가 성공적으로 삭제됐습니다.');
@@ -27,11 +59,7 @@ function ProjectAdminDelete({ id }: { id: number }) {
     },
   });
 
-  const handleDelete = () => {
-    mutation.mutate(id);
-  };
-
-  return <DeleteButton onClick={handleDelete}>삭제</DeleteButton>;
+  return <DeleteButton onClick={() => mutation.mutate(id)}>삭제</DeleteButton>;
 }
 
 export default ProjectAdminDelete;

--- a/src/components/Project/Delete/ProjectAdminDelete.tsx
+++ b/src/components/Project/Delete/ProjectAdminDelete.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { deleteProject } from '~/api/project.ts';
+import { deleteProject, getProjects } from '~/api/project.ts';
 import { deleteTag, getBoardsByCategory } from '~/api/board.ts';
 import { ProjectTag } from '~/models/Project.ts';
 import { CATEGORY } from '~/constants/category.ts';
@@ -44,8 +44,35 @@ function ProjectAdminDelete({ id, tags }: { id: number; tags?: ProjectTag[] }) {
           board.tags?.forEach((tag) => academicTagIds.add(tag.id));
         });
 
-        // 아카데믹 게시글에서 사용 중이지 않은 태그만 삭제
-        const tagsToDelete = tags.filter((tag) => !academicTagIds.has(tag.id));
+        // 다른 프로젝트에서 사용 중인 태그 ID 수집 (현재 삭제할 프로젝트 제외)
+        const firstProjectPage = await getProjects(1, 1000);
+        const totalProjectPages = firstProjectPage.totalPages ?? 1;
+        const allProjects = Array.isArray(firstProjectPage.resListProjectDtos)
+          ? [...(firstProjectPage.resListProjectDtos as any[])]
+          : [];
+        if (totalProjectPages > 1) {
+          const remainingProjectPages = await Promise.all(
+            Array.from({ length: totalProjectPages - 1 }, (_, i) =>
+              getProjects(i + 2, 1000),
+            ),
+          );
+          remainingProjectPages.forEach((page) => {
+            if (Array.isArray(page.resListProjectDtos)) {
+              allProjects.push(...(page.resListProjectDtos as any[]));
+            }
+          });
+        }
+        const otherProjectTagIds = new Set<number>();
+        allProjects
+          .filter((project: any) => project.id !== id)
+          .forEach((project: any) =>
+            project.tags?.forEach((tag: { id: number }) => otherProjectTagIds.add(tag.id)),
+          );
+
+        // 아카데믹 게시글과 다른 프로젝트 어디서도 사용 중이지 않은 태그만 삭제
+        const tagsToDelete = tags.filter(
+          (tag) => !academicTagIds.has(tag.id) && !otherProjectTagIds.has(tag.id),
+        );
         await Promise.all(tagsToDelete.map((tag) => deleteTag(tag.id)));
       }
       return deleteProject(id);

--- a/src/components/Project/Detail/ProjectDetail.tsx
+++ b/src/components/Project/Detail/ProjectDetail.tsx
@@ -1,8 +1,12 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { Project } from '~/models/Project.ts';
 import { QUERY_KEY } from '~/api/queryKey.ts';
 import { getProjectById } from '~/api/project.ts';
+import { CATEGORY } from '~/constants/category.ts';
+import { CATEGORY_STRINGS_EN } from '~/constants/category_strings_en.ts';
+import { useAllAcademicBoards } from '~/hooks/useAllAcademicBoards.ts';
 import styled from 'styled-components';
 import LoadingSpinner from '~/components/Common/LoadingSpinner';
 
@@ -204,6 +208,57 @@ const MemberChip = styled.span`
   color: #334155;
 `;
 
+const RelatedBoardRow = styled(Link)`
+  display: flex;
+  align-items: center;
+  background: white;
+  border-radius: 10px;
+  border: 1px solid #e8edf3;
+  padding: 0.875rem 1.25rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+  gap: 1rem;
+  text-decoration: none;
+  transition: box-shadow 0.12s;
+
+  &:hover {
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.09);
+  }
+`;
+
+const RelatedBoardTitle = styled.span`
+  font-family: 'Pretendard SemiBold';
+  font-size: 15px;
+  color: #1e293b;
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const RelatedBoardTags = styled.div`
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 6px;
+  flex-shrink: 0;
+`;
+
+const RelatedBoardTag = styled.span`
+  padding: 3px 10px;
+  background: rgba(44, 180, 219, 0.1);
+  border: 1px solid #c9eef8;
+  color: #1a8fa8;
+  border-radius: 4px;
+  font-family: 'Pretendard Regular';
+  font-size: 12px;
+  white-space: nowrap;
+`;
+
+const RelatedList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
 function toAbsoluteUrl(url: string) {
   return /^https?:\/\//i.test(url) ? url : `https://${url}`;
 }
@@ -218,6 +273,20 @@ function ProjectDetail() {
     queryKey: QUERY_KEY.project.projectById(projectId),
     queryFn: async () => getProjectById(projectId),
   });
+
+  const allAcademicBoards = useAllAcademicBoards();
+
+  const projectTagIds = useMemo(
+    () => new Set(projectQuery.data?.tags?.map((t) => t.id) ?? []),
+    [projectQuery.data],
+  );
+  const relatedBoards = useMemo(
+    () =>
+      allAcademicBoards.filter((b) =>
+        b.tags?.some((t) => projectTagIds.has(t.id)),
+      ),
+    [allAcademicBoards, projectTagIds],
+  );
 
   if (projectQuery.isLoading) return <LoadingSpinner />;
   if (projectQuery.isError) return <div>에러가 발생했습니다.</div>;
@@ -242,76 +311,95 @@ function ProjectDetail() {
         <TeamName>{project.teamName}</TeamName>
       </ProjectInfo>
 
-      <>
-        <Card>
-          <CardTitle>프로젝트 소개</CardTitle>
-          <Field>
-            <FieldValue>{project.content}</FieldValue>
-          </Field>
-        </Card>
+      <Card>
+        <CardTitle>프로젝트 소개</CardTitle>
+        <Field>
+          <FieldValue>{project.content}</FieldValue>
+        </Field>
+      </Card>
 
-        <Card>
-          <CardTitle>링크</CardTitle>
-          <FieldGrid>
-            <Field>
-              <FieldLabel>GitHub</FieldLabel>
-              {project.gitHubUrl ? (
-                <LinkValue
-                  href={toAbsoluteUrl(project.gitHubUrl)}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {project.gitHubUrl}
-                </LinkValue>
-              ) : (
-                <EmptyValue>없음</EmptyValue>
-              )}
-            </Field>
-            <Field>
-              <FieldLabel>서비스 URL</FieldLabel>
-              {project.serviceUrl ? (
-                <LinkValue
-                  href={toAbsoluteUrl(project.serviceUrl)}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {project.serviceUrl}
-                </LinkValue>
-              ) : (
-                <EmptyValue>없음</EmptyValue>
-              )}
-            </Field>
-          </FieldGrid>
-        </Card>
-
-        <Card>
-          <CardTitle>팀원 & 태그</CardTitle>
+      <Card>
+        <CardTitle>링크</CardTitle>
+        <FieldGrid>
           <Field>
-            <FieldLabel>팀원</FieldLabel>
-            <PillRow>
-              {project.members.length > 0 ? (
-                project.members.map((member, i) => (
-                  <MemberChip key={i}>{member}</MemberChip>
-                ))
-              ) : (
-                <EmptyValue>없음</EmptyValue>
-              )}
-            </PillRow>
+            <FieldLabel>GitHub</FieldLabel>
+            {project.gitHubUrl ? (
+              <LinkValue
+                href={toAbsoluteUrl(project.gitHubUrl)}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {project.gitHubUrl}
+              </LinkValue>
+            ) : (
+              <EmptyValue>없음</EmptyValue>
+            )}
           </Field>
-          <Field style={{ marginTop: '1.25rem' }}>
-            <FieldLabel>태그</FieldLabel>
-            <PillRow>
-              {project.tags && project.tags.length > 0 ? (
-                project.tags.map((tag) => (
-                  <TagPill key={tag.id}>{tag.name}</TagPill>
-                ))
-              ) : (
-                <EmptyValue>없음</EmptyValue>
-              )}
-            </PillRow>
+          <Field>
+            <FieldLabel>서비스 URL</FieldLabel>
+            {project.serviceUrl ? (
+              <LinkValue
+                href={toAbsoluteUrl(project.serviceUrl)}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {project.serviceUrl}
+              </LinkValue>
+            ) : (
+              <EmptyValue>없음</EmptyValue>
+            )}
           </Field>
+        </FieldGrid>
+      </Card>
+
+      <Card>
+        <CardTitle>팀원 & 태그</CardTitle>
+        <Field>
+          <FieldLabel>팀원</FieldLabel>
+          <PillRow>
+            {project.members.length > 0 ? (
+              project.members.map((member, i) => (
+                <MemberChip key={i}>{member}</MemberChip>
+              ))
+            ) : (
+              <EmptyValue>없음</EmptyValue>
+            )}
+          </PillRow>
+        </Field>
+        <Field style={{ marginTop: '1.25rem' }}>
+          <FieldLabel>태그</FieldLabel>
+          <PillRow>
+            {project.tags && project.tags.length > 0 ? (
+              project.tags.map((tag) => (
+                <TagPill key={tag.id}>{tag.name}</TagPill>
+              ))
+            ) : (
+              <EmptyValue>없음</EmptyValue>
+            )}
+          </PillRow>
+        </Field>
+      </Card>
+
+      {relatedBoards.length > 0 && (
+        <Card>
+          <CardTitle>관련 학술 게시글</CardTitle>
+          <RelatedList>
+            {relatedBoards.map((board) => (
+              <RelatedBoardRow
+                key={board.id}
+                to={`/${CATEGORY_STRINGS_EN[CATEGORY.ACADEMIC]}/view/${board.id}`}
+              >
+                <RelatedBoardTitle>{board.title}</RelatedBoardTitle>
+                <RelatedBoardTags>
+                  {board.tags?.map((tag) => (
+                    <RelatedBoardTag key={tag.id}>{tag.name}</RelatedBoardTag>
+                  ))}
+                </RelatedBoardTags>
+              </RelatedBoardRow>
+            ))}
+          </RelatedList>
         </Card>
-      </>
+      )}
     </PageWrapper>
   );
 }

--- a/src/components/Project/List/ProjectAdminList.tsx
+++ b/src/components/Project/List/ProjectAdminList.tsx
@@ -163,7 +163,7 @@ function ProjectAdminList({
             <TeamName>{project.teamName}</TeamName>
             <Actions onClick={(e) => e.preventDefault()}>
               <EditLink to={`/admin/project/edit/${project.id}`}>수정</EditLink>
-              <ProjectDelete id={project.id!} />
+              <ProjectDelete id={project.id!} tags={project.tags} />
             </Actions>
           </Row>
         ))}

--- a/src/components/Project/List/ProjectList.tsx
+++ b/src/components/Project/List/ProjectList.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Project } from '~/models/Project.ts';
+import { useAllTags } from '~/hooks/useAllTags.ts';
 import ProjectItem from '~/components/Project/Item/ProjectItem.tsx';
 import styles from './ProjectList.module.css';
 import Pagination from '~/components/Pagination/Pagination';
@@ -19,22 +20,18 @@ export default function ProjectList({
 }: ProjectListProps) {
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
 
-  const allTags = Array.from(
-    new Set(projectsQuery.flatMap((p) => p.tags?.map((t) => t.name) ?? [])),
-  );
+  const allTags = useAllTags();
 
   const filtered = selectedTag
     ? projectsQuery.filter((p) => p.tags?.some((t) => t.name === selectedTag))
     : projectsQuery;
 
   const renderBoardContent = () => {
-    return filtered
-      .filter((project) => project.id !== undefined)
-      .map((project) => (
-        <div key={`board-${project.id}`} className={styles['board-wrapper']}>
-          <ProjectItem project={project} />
-        </div>
-      ));
+    return filtered.map((project) => (
+      <div key={`board-${project.id}`} className={styles['board-wrapper']}>
+        <ProjectItem project={project} />
+      </div>
+    ));
   };
 
   return (
@@ -51,16 +48,16 @@ export default function ProjectList({
             <rect x="0" y="7.5" width="5.5" height="5.5" rx="1" />
             <rect x="7.5" y="7.5" width="5.5" height="5.5" rx="1" />
           </svg>
-          All Projects
+          All
         </button>
         <div className={styles.tagScrollArea}>
           {allTags.map((tag) => (
             <button
-              key={tag}
-              className={`${styles.tagFilterButton} ${selectedTag === tag ? styles.tagFilterButtonActive : ''}`}
-              onClick={() => setSelectedTag(tag)}
+              key={tag.id}
+              className={`${styles.tagFilterButton} ${selectedTag === tag.name ? styles.tagFilterButtonActive : ''}`}
+              onClick={() => setSelectedTag(tag.name)}
             >
-              {tag}
+              {tag.name}
             </button>
           ))}
         </div>

--- a/src/hooks/useAllAcademicBoards.ts
+++ b/src/hooks/useAllAcademicBoards.ts
@@ -1,0 +1,30 @@
+import { useQuery, useQueries } from '@tanstack/react-query';
+import { Board, BoardPageList } from '~/models/Board.ts';
+import { getBoardsByCategory } from '~/api/board.ts';
+import { CATEGORY } from '~/constants/category.ts';
+import { QUERY_KEY } from '~/api/queryKey.ts';
+
+export function useAllAcademicBoards(enabled = true): Board[] {
+  const page0Query = useQuery<BoardPageList>({
+    queryKey: QUERY_KEY.board.boards(CATEGORY.ACADEMIC, 0),
+    queryFn: () => getBoardsByCategory(CATEGORY.ACADEMIC, 0),
+    staleTime: 5 * 60 * 1000,
+    enabled,
+  });
+
+  const totalPages = page0Query.data?.totalPages ?? 1;
+
+  const remainingQueries = useQueries({
+    queries: Array.from({ length: Math.max(0, totalPages - 1) }, (_, i) => ({
+      queryKey: QUERY_KEY.board.boards(CATEGORY.ACADEMIC, i + 1),
+      queryFn: () => getBoardsByCategory(CATEGORY.ACADEMIC, i + 1),
+      staleTime: 5 * 60 * 1000,
+      enabled,
+    })),
+  });
+
+  return [
+    ...(page0Query.data?.resListBoardDtos ?? []),
+    ...remainingQueries.flatMap((q) => q.data?.resListBoardDtos ?? []),
+  ];
+}

--- a/src/hooks/useAllTags.ts
+++ b/src/hooks/useAllTags.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { getAllTags } from '~/api/board';
+
+export function useAllTags(enabled = true): { id: number; name: string }[] {
+  const { data } = useQuery({
+    queryKey: ['tags.all'],
+    queryFn: getAllTags,
+    staleTime: 5 * 60 * 1000,
+    enabled,
+  });
+  return data ?? [];
+}

--- a/src/models/Board.ts
+++ b/src/models/Board.ts
@@ -1,5 +1,10 @@
 import { Comment } from './Comment';
 
+export interface BoardTag {
+  id: number;
+  name: string;
+}
+
 export interface BoardPageList {
   resListBoardDtos?: Board[];
   resBoardPinDtos?: Board[];
@@ -44,6 +49,8 @@ export interface Board {
     professor?: string;
   };
   resListCommentDtos?: Comment[];
+  tagNames?: string[];
+  tags?: BoardTag[];
 }
 export interface UpdateBoard {
   title: string;
@@ -51,4 +58,5 @@ export interface UpdateBoard {
   imageUrls?: string[];
   isChangedFile: boolean;
   deleted: boolean;
+  tags?: string[];
 }


### PR DESCRIPTION
## Summary

### 1. 태그 모델·API 기반 작업
- `BoardTag` 인터페이스 추가 (`id`, `name`)
- `Board`, `UpdateBoard` 타입에 `tags` 필드 반영
- `GET /api/tags` 기반 `getAllTags` API 함수 추가
- `DELETE /tags/{id}` 기반 `deleteTag` API 함수 추가
- `updateBoards` 페이로드에 `tags` 포함

### 2. 게시글 작성·수정 태그 UI
- 게시글 작성(`BoardWrite`), 수정(`BoardEdit`)에 태그 입력 필드 추가
- Enter로 태그 추가, ✕ 버튼으로 개별 삭제
- 수정 시 기존 태그 불러와 편집 가능
- 수정 성공 후 React Query 캐시 무효화로 새로고침 없이 자동 갱신

### 3. 게시글 상세 태그 표시
- 게시글 본문 하단에 태그 칩(chip) UI로 태그 목록 표시

### 4. 삭제 시 태그 안전 정리
- 게시글 삭제: 해당 태그가 다른 게시글·프로젝트 어디서도 사용 중이지 않을 때만 삭제
- 프로젝트 삭제: 해당 태그가 다른 게시글·프로젝트 어디서도 사용 중이지 않을 때만 삭제

### 5. 태그 필터 (목록 화면)
- `GET /api/tags` 단일 호출 기반 `useAllTags` 훅 추가 (기존 전 페이지 fetch 방식 개선)
- 학술 게시판(`BoardList`) 상단에 태그 필터 바 추가
- 프로젝트 목록(`ProjectList`) 태그 필터를 공유 태그 기반으로 개선
- `useAllAcademicBoards` 훅에 `enabled` 파라미터 추가 — 필요할 때만 fetch

### 6. 프로젝트 상세 관련 학술 게시글
- 프로젝트와 태그가 겹치는 학술 게시글을 "관련 학술 게시글" 섹션으로 표시
- `useMemo`로 태그 Set·필터 연산 최적화

### 7. 기타 정리
- `CommentList`: null 체크 단순화, 중복 `key` prop 제거, 불필요한 주석 정리

## Test plan
- [ ] 게시글 작성 시 태그 추가·삭제 동작 확인
- [ ] 게시글 수정 시 기존 태그 표시 및 편집 후 저장 확인
- [ ] 게시글 수정 후 상세 페이지에서 새로고침 없이 변경 내용 반영 확인
- [ ] 게시글 삭제 시 다른 게시글·프로젝트와 공유된 태그는 유지되는지 확인
- [ ] 학술 게시판 태그 필터 동작 확인
- [ ] 프로젝트 목록 태그 필터 동작 확인
- [ ] 프로젝트 상세에서 관련 학술 게시글 섹션 표시 확인
- [ ] 프로젝트 삭제 시 다른 게시글·프로젝트와 공유된 태그는 유지되는지 확인